### PR TITLE
Add relay configuration settings and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Luge Relay Controller
+
+This project provides a simple three-beep timing sequence and optional relay control for starting gates.
+
+## Configuration
+
+Relay behavior can be customized in `config.py`:
+
+- `RELAY_PIN` – BCM pin number connected to the relay
+- `RELAY_ACTIVE_HIGH` – set to `True` if the relay is triggered by a high signal
+- `GATE_OPEN_DURATION` – number of seconds the gate stays open after the final beep
+
+Adjust these values to match your hardware setup.
+
+## Installation
+
+Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Start the web interface:
+
+```bash
+python app.py
+```
+
+Open a browser to `http://localhost:5000` to control the sequence.

--- a/config.py
+++ b/config.py
@@ -30,3 +30,8 @@ class Config:
     # Web interface settings
     AUTO_REFRESH_INTERVAL = 100  # milliseconds for status updates
     COUNTDOWN_UPDATE_INTERVAL = 50  # milliseconds for countdown updates 
+    
+    # Relay control settings
+    RELAY_PIN = 17      # BCM numbering
+    RELAY_ACTIVE_HIGH = True
+    GATE_OPEN_DURATION = 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ MarkupSafe==2.1.3
 itsdangerous==2.1.2
 click==8.1.7
 blinker==1.6.3 
+gpiozero


### PR DESCRIPTION
## Summary
- Add relay pin, active level, and gate open duration configuration options
- Include `gpiozero` dependency for GPIO control
- Document relay configuration in new README

## Testing
- `python test_setup.py` *(fails: Audio system - No such audio device)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ea2d1618832291144c6330900e2d